### PR TITLE
feat: add `toBeScheduled` expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ expect($model)->toBeModel($anotherModel);
 
 The expectation will only pass if both models are Eloquent models of the same class, with the same key.
 
+#### toBeScheduled
+
+Expect that a value is a scheduled job, command or invokable class.
+
+```php
+expect(MyJob::class)->toBeScheduled('0 * * * *');
+```
+
+Optionally, you may pass a callback that accepts an `Illuminate\Console\Scheduling\Event` or `Illuminate\Console\Scheduling\CallbackEvent` instance, so you can run any assertion needed:
+
+```php
+expect(MyArtisanCommand::class)->toBeScheduled(function (Event $event) {
+    expect($event->getExpression())->toBe('0 0 * * *');
+    expect($event->getSummaryForDisplay())->toBe('Foo');
+});
+```
+
 ### Helpers
 
 This package offers various helpers that you can tack on any test. Here's an example of the `whenGitHubActions` helper. When tacked on to a test, the test will be skipped unless you're running it on GitHub Actions.

--- a/tests/TestSupport/Scheduled/CommandClass.php
+++ b/tests/TestSupport/Scheduled/CommandClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\PestExpectations\Tests\TestSupport\Scheduled;
+
+use Illuminate\Console\Command;
+
+final class CommandClass extends Command
+{
+    protected $signature = 'foo:bar';
+}

--- a/tests/TestSupport/Scheduled/InvokableClass.php
+++ b/tests/TestSupport/Scheduled/InvokableClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\PestExpectations\Tests\TestSupport\Scheduled;
+
+final class InvokableClass
+{
+    public function __invoke()
+    {
+    }
+}

--- a/tests/TestSupport/Scheduled/JobClass.php
+++ b/tests/TestSupport/Scheduled/JobClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\PestExpectations\Tests\TestSupport\Scheduled;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+final class JobClass implements ShouldQueue
+{
+    use Batchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __invoke(): void
+    {
+
+    }
+}

--- a/tests/ToBeScheduledTest.php
+++ b/tests/ToBeScheduledTest.php
@@ -7,50 +7,44 @@ use Spatie\PestExpectations\Tests\TestSupport\Scheduled\CommandClass;
 use Spatie\PestExpectations\Tests\TestSupport\Scheduled\InvokableClass;
 use Spatie\PestExpectations\Tests\TestSupport\Scheduled\JobClass;
 
-describe('call', function () {
-    it('can assert a class is scheduled by passing a cron expression', function () {
-        Schedule::call(InvokableClass::class)->hourly();
-        expect(InvokableClass::class)->toBeScheduled('0 * * * *');
-    });
+it('can assert a class is scheduled by passing a cron expression', function () {
+    Schedule::call(InvokableClass::class)->hourly();
+    expect(InvokableClass::class)->toBeScheduled('0 * * * *');
+});
 
-    it('can use a callback to assert anything on a scheduled class', function () {
-        Schedule::call(InvokableClass::class)->hourly();
+it('can use a callback to assert anything on a scheduled class', function () {
+    Schedule::call(InvokableClass::class)->hourly();
 
-        expect(InvokableClass::class)->toBeScheduled(function (CallbackEvent $event) {
-            expect($event->getExpression())->toBe('0 * * * *');
-            expect($event->getSummaryForDisplay())->toBe(InvokableClass::class);
-        });
+    expect(InvokableClass::class)->toBeScheduled(function (CallbackEvent $event) {
+        expect($event->getExpression())->toBe('0 * * * *');
+        expect($event->getSummaryForDisplay())->toBe(InvokableClass::class);
     });
 });
 
-describe('command', function () {
-    it('can assert a command is scheduled by passing a cron expression', function () {
-        Schedule::command(CommandClass::class)->daily();
-        expect(CommandClass::class)->toBeScheduled('0 0 * * *');
-    });
+it('can assert a command is scheduled by passing a cron expression', function () {
+    Schedule::command(CommandClass::class)->daily();
+    expect(CommandClass::class)->toBeScheduled('0 0 * * *');
+});
 
-    it('can use a callback to assert anything on a scheduled command', function () {
-        Schedule::command(CommandClass::class)->daily()->description('Foo');
+it('can use a callback to assert anything on a scheduled command', function () {
+    Schedule::command(CommandClass::class)->daily()->description('Foo');
 
-        expect(CommandClass::class)->toBeScheduled(function (Event $event) {
-            expect($event->getExpression())->toBe('0 0 * * *');
-            expect($event->getSummaryForDisplay())->toBe('Foo');
-        });
+    expect(CommandClass::class)->toBeScheduled(function (Event $event) {
+        expect($event->getExpression())->toBe('0 0 * * *');
+        expect($event->getSummaryForDisplay())->toBe('Foo');
     });
 });
 
-describe('job', function () {
-    it('can assert a job is scheduled by passing a cron expression', function () {
-        Schedule::job(JobClass::class)->daily();
-        expect(JobClass::class)->toBeScheduled('0 0 * * *');
-    });
+it('can assert a job is scheduled by passing a cron expression', function () {
+    Schedule::job(JobClass::class)->daily();
+    expect(JobClass::class)->toBeScheduled('0 0 * * *');
+});
 
-    it('can use a callback to assert anything on a scheduled job', function () {
-        Schedule::job(JobClass::class)->daily();
+it('can use a callback to assert anything on a scheduled job', function () {
+    Schedule::job(JobClass::class)->daily();
 
-        expect(JobClass::class)->toBeScheduled(function (Event $event) {
-            expect($event->getExpression())->toBe('0 0 * * *');
-            expect($event->getSummaryForDisplay())->toBe(JobClass::class);
-        });
+    expect(JobClass::class)->toBeScheduled(function (Event $event) {
+        expect($event->getExpression())->toBe('0 0 * * *');
+        expect($event->getSummaryForDisplay())->toBe(JobClass::class);
     });
 });

--- a/tests/ToBeScheduledTest.php
+++ b/tests/ToBeScheduledTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Console\Scheduling\CallbackEvent;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Support\Facades\Schedule;
+use Spatie\PestExpectations\Tests\TestSupport\Scheduled\CommandClass;
+use Spatie\PestExpectations\Tests\TestSupport\Scheduled\InvokableClass;
+use Spatie\PestExpectations\Tests\TestSupport\Scheduled\JobClass;
+
+describe('call', function () {
+    it('can assert a class is scheduled by passing a cron expression', function () {
+        Schedule::call(InvokableClass::class)->hourly();
+        expect(InvokableClass::class)->toBeScheduled('0 * * * *');
+    });
+
+    it('can use a callback to assert anything on a scheduled class', function () {
+        Schedule::call(InvokableClass::class)->hourly();
+
+        expect(InvokableClass::class)->toBeScheduled(function (CallbackEvent $event) {
+            expect($event->getExpression())->toBe('0 * * * *');
+            expect($event->getSummaryForDisplay())->toBe(InvokableClass::class);
+        });
+    });
+});
+
+describe('command', function () {
+    it('can assert a command is scheduled by passing a cron expression', function () {
+        Schedule::command(CommandClass::class)->daily();
+        expect(CommandClass::class)->toBeScheduled('0 0 * * *');
+    });
+
+    it('can use a callback to assert anything on a scheduled command', function () {
+        Schedule::command(CommandClass::class)->daily()->description('Foo');
+
+        expect(CommandClass::class)->toBeScheduled(function (Event $event) {
+            expect($event->getExpression())->toBe('0 0 * * *');
+            expect($event->getSummaryForDisplay())->toBe('Foo');
+        });
+    });
+});
+
+describe('job', function () {
+    it('can assert a job is scheduled by passing a cron expression', function () {
+        Schedule::job(JobClass::class)->daily();
+        expect(JobClass::class)->toBeScheduled('0 0 * * *');
+    });
+
+    it('can use a callback to assert anything on a scheduled job', function () {
+        Schedule::job(JobClass::class)->daily();
+
+        expect(JobClass::class)->toBeScheduled(function (Event $event) {
+            expect($event->getExpression())->toBe('0 0 * * *');
+            expect($event->getSummaryForDisplay())->toBe(JobClass::class);
+        });
+    });
+});


### PR DESCRIPTION
This pull request adds a new `toBeScheduled` expectation that eases the process of asserting that invokable classes, commands or jobs are scheduled.

```php
// With a cron expression
expect(InvokableClass::class)->toBeScheduled('0 * * * *')

// With a callback
expect(CommandClass::class)->toBeScheduled(function (Event $event) {
    expect($event->getExpression())->toBe('0 0 * * *');
    expect($event->getSummaryForDisplay())->toBe('Foo');
})
```