### PR TITLE
feat: add `toBeArrayOf` expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ expect($model)->toBeModel($anotherModel);
 
 The expectation will only pass if both models are Eloquent models of the same class, with the same key.
 
+#### toBeArrayOf
+
+Expect that a value is an array of the specified value.
+
+```php
+expect(User::all())->toBeArrayOf(User::class);
+```
+
+The specified value may be a class name or a class instance, or one of the following string values:
+- `'string'`
+- `'int'`
+- `'float'`
+- `'bool'`
+- `'scalar'`
+- `'array'`
+- `'object'`
+- `'null'`
+
+```php
+expect([1, 2])->toBeArrayOf('int');
+expect([true, false])->toBeArrayOf('bool');
+expect(['foo', 1, false])->toBeArrayOf('scalar');
+```
+
 #### toBeScheduled
 
 Expect that a value is a scheduled job, command or invokable class.

--- a/src/PestExpectations.php
+++ b/src/PestExpectations.php
@@ -141,3 +141,27 @@ expect()->extend('toHaveJsonApiPagination', function () {
         'total',
     ]);
 });
+
+expect()->extend('toBeArrayOf', function (string|object $class) {
+    if (is_object($class)) {
+        $class = get_class($class);
+    }
+
+    expect($this->value)->toBeArray();
+
+    foreach ($this->value as $value) {
+        match ($class) {
+            'string' => expect($value)->toBeString(),
+            'int' => expect($value)->toBeInt(),
+            'integer' => expect($value)->toBeInt(),
+            'float' => expect($value)->toBeFloat(),
+            'bool' => expect($value)->toBeBool(),
+            'boolean' => expect($value)->toBeBool(),
+            'scalar' => expect($value)->toBeScalar(),
+            'array' => expect($value)->toBeArray(),
+            'object' => expect($value)->toBeObject(),
+            'null' => expect($value)->toBeNull(),
+            default => expect($value)->toBeInstanceOf($class)
+        };
+    }
+});

--- a/tests/TestSupport/UserData.php
+++ b/tests/TestSupport/UserData.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\PestExpectations\Tests\TestSupport;
+
+final class UserData
+{
+    public function __construct(
+        public readonly string $full_name
+    ) {
+    }
+}

--- a/tests/ToBeArrayOfTest.php
+++ b/tests/ToBeArrayOfTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\PestExpectations\Tests\TestSupport\Models\Post;
+use Spatie\PestExpectations\Tests\TestSupport\TestEnum;
+use Spatie\PestExpectations\Tests\TestSupport\UserData;
+
+test('expects given arrays to be of specified types', function (array $array, string|object $expect) {
+    expect($array)->toBeArrayOf($expect);
+})->with([
+    // specific scalar values
+    [['foo', 'bar'], 'string'],
+    [[1, 2], 'int'],
+    [[1, 2], 'integer'],
+    [[1.1, 2.2], 'float'],
+    [[true, false], 'bool'],
+    [[true, false], 'boolean'],
+    [[['foo', 'bar'], ['baz', 'qux']], 'array'],
+    [[null, null], 'null'],
+    // generic scalar
+    [['foo', 'bar'], 'scalar'],
+    [[1, 2], 'scalar'],
+    [[1.1, 2.2], 'scalar'],
+    [[true, false], 'scalar'],
+    [[1, 'foo', 1.1, true], 'scalar'],
+    // objects
+    [[new stdClass(), new stdClass()], stdClass::class],
+    [[new stdClass(), new stdClass()], new stdClass()],
+    [[new stdClass(), new stdClass()], 'object'],
+    [[new stdClass(), (object) []], stdClass::class],
+    // enums
+    [[TestEnum::first, TestEnum::second], TestEnum::class],
+    [[TestEnum::first, TestEnum::second], BackedEnum::class],
+    // class
+    [[new UserData('Jon Doe'), new UserData('Jane Doe')], UserData::class],
+    [[new UserData('Jon Doe'), new UserData('Jane Doe')], new UserData('Jane Doe')],
+    [[new Post(), new Post()], Post::class],
+    [[new Post(), new Post()], Model::class],
+]);
+
+test('expects given arrays not to be of specified types', function (array $array, string|object $expect) {
+    expect($array)->not->toBeArrayOf($expect);
+})->with([
+    // classes with other classes
+    [[new stdClass(), new UserData('Jon Doe')], UserData::class],
+    [[new Post(), new stdClass()], UserData::class],
+    [[new stdClass(), new UserData('Jon Doe')], stdClass::class],
+    [[new Post(), new stdClass()], stdClass::class],
+    // scalar
+    [[1, 2.2], 'int'],
+    [[1, 2.2], 'float'],
+    [[1, '1'], 'int'],
+    [[1, '1'], 'string'],
+    [[1.0, '1'], 'float'],
+    [[1.0, '1'], 'string'],
+]);


### PR DESCRIPTION
This pull request adds the `toBeArrayOf` expectation, which asserts a specific value is an array of the specified type.

```php
expect(User::all())->toBeArrayOf(User::class);
```

I very often have to deal with arrays of data objects and I copy-paste this expectation in a lot of projects:

```php
expect(FlightData::collectFromFl3xxFlights($response))
        ->toBeArrayOf(FlightData::class)
        ->toHaveCount(8);
```

I'm also thinking of either adding `toBeCollectionOf`, or supporting collections in `toBeArrayOf`. What do you think?