### PR TITLE
feat: add timezone parameter to `toBeScheduled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ expect(['foo', 1, false])->toBeArrayOf('scalar');
 
 #### toBeScheduled
 
-Expect that a value is a scheduled job, command or invokable class.
+Expect that a value is a scheduled job, command or invokable class. The `timezone` parameter, if passed, will also check that the specified timezone was defined.
 
 ```php
-expect(MyJob::class)->toBeScheduled('0 * * * *');
+expect(MyJob::class)->toBeScheduled('0 * * * *', timezone: 'Europe/Paris');
 ```
 
 Optionally, you may pass a callback that accepts an `Illuminate\Console\Scheduling\Event` or `Illuminate\Console\Scheduling\CallbackEvent` instance, so you can run any assertion needed:

--- a/src/PestExpectations.php
+++ b/src/PestExpectations.php
@@ -91,7 +91,7 @@ expect()->extend('toBeModel', function ($argument) {
     expect($this->value->getKey())->toBe($argument->getKey(), 'Value is not the same model');
 });
 
-expect()->extend('toBeScheduled', function (string|\Closure $callback) {
+expect()->extend('toBeScheduled', function (string|\Closure $callback, ?string $timezone = null) {
     expect(class_exists($this->value))->toBeTrue("Expected `{$this->value}` to be a class.");
 
     $schedule = resolve(Schedule::class);
@@ -111,7 +111,13 @@ expect()->extend('toBeScheduled', function (string|\Closure $callback) {
     assertNotNull($event, sprintf('Expected `%s` to be scheduled.', $this->value));
 
     if (is_string($callback)) {
-        $callback = fn (CallbackEvent|Event $event) => assertEquals($callback, $event->expression);
+        $callback = function (CallbackEvent|Event $event) use ($callback, $timezone) {
+            assertEquals($callback, $event->expression);
+
+            if (is_string($timezone)) {
+                assertEquals($timezone, $event->timezone);
+            }
+        };
     }
 
     $callback($event);

--- a/tests/TestSupport/Models/Post.php
+++ b/tests/TestSupport/Models/Post.php
@@ -4,6 +4,4 @@ namespace Spatie\PestExpectations\Tests\TestSupport\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Post extends Model
-{
-}
+class Post extends Model {}

--- a/tests/TestSupport/Scheduled/InvokableClass.php
+++ b/tests/TestSupport/Scheduled/InvokableClass.php
@@ -4,7 +4,5 @@ namespace Spatie\PestExpectations\Tests\TestSupport\Scheduled;
 
 final class InvokableClass
 {
-    public function __invoke()
-    {
-    }
+    public function __invoke() {}
 }

--- a/tests/TestSupport/Scheduled/JobClass.php
+++ b/tests/TestSupport/Scheduled/JobClass.php
@@ -15,8 +15,5 @@ final class JobClass implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public function __invoke(): void
-    {
-
-    }
+    public function __invoke(): void {}
 }

--- a/tests/TestSupport/UserData.php
+++ b/tests/TestSupport/UserData.php
@@ -6,6 +6,5 @@ final class UserData
 {
     public function __construct(
         public readonly string $full_name
-    ) {
-    }
+    ) {}
 }

--- a/tests/ToBeScheduledTest.php
+++ b/tests/ToBeScheduledTest.php
@@ -12,6 +12,12 @@ it('can assert a class is scheduled by passing a cron expression', function () {
     expect(InvokableClass::class)->toBeScheduled('0 * * * *');
 });
 
+it('can assert a class is scheduled by passing a cron expression and a timezone', function () {
+    Schedule::call(InvokableClass::class)->hourly()->timezone('Europe/Paris');
+    expect(InvokableClass::class)->toBeScheduled('0 * * * *', timezone: 'Europe/Paris');
+});
+
+
 it('can use a callback to assert anything on a scheduled class', function () {
     Schedule::call(InvokableClass::class)->hourly();
 

--- a/tests/ToBeScheduledTest.php
+++ b/tests/ToBeScheduledTest.php
@@ -17,7 +17,6 @@ it('can assert a class is scheduled by passing a cron expression and a timezone'
     expect(InvokableClass::class)->toBeScheduled('0 * * * *', timezone: 'Europe/Paris');
 });
 
-
 it('can use a callback to assert anything on a scheduled class', function () {
     Schedule::call(InvokableClass::class)->hourly();
 


### PR DESCRIPTION
This pull request adds a `timezone` parameter to `toBeScheduled`. If specified, the assertion will ensure the specified timezone has been defined on the scheduler.

```php
expect(MyJob::class)->toBeScheduled('0 * * * *', timezone: 'Europe/Paris');
```